### PR TITLE
Icon width CSS fix

### DIFF
--- a/src/components/EventCard/style.scss
+++ b/src/components/EventCard/style.scss
@@ -1,3 +1,6 @@
 .event-card {
     width: 100%;
+    .ant-card-actions > li > span i {
+        width: unset;
+    }
 }


### PR DESCRIPTION
Added a CSS rule that fixes the events button alignment issue, #101 

I'd still like to know how this mis-alignment happened in the first place -- it's confusing because the only CSS that affects the icons comes with the AntD package -- but if we just need a quick fix this does the job