### PR TITLE
Cleanup warnings

### DIFF
--- a/src/components/EditAddressOrDateButton/index.js
+++ b/src/components/EditAddressOrDateButton/index.js
@@ -3,7 +3,6 @@ import {
   Icon,
 } from 'antd';
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import EditAddressOrDateModal from '../EditAddressOrDateModal';
 

--- a/src/components/EventCard/IconFlagSelect.js
+++ b/src/components/EventCard/IconFlagSelect.js
@@ -3,10 +3,6 @@ import { Select } from 'antd';
 
 const Option = Select.Option;
 
-function handleChange(value) {
-  console.log(`selected ${value}`);
-}
-
 export const IN_PERSON_ICON_FLAG = 'in-person';
 export const ACTIVISM_ICON_FLAG = 'activism';
 export const TELE_ICON_FLAG = 'tele';

--- a/src/components/EventCard/MeetingTypeSelect.js
+++ b/src/components/EventCard/MeetingTypeSelect.js
@@ -3,10 +3,6 @@ import { Select } from 'antd';
 
 const Option = Select.Option;
 
-function handleChange(value) {
-  console.log(`selected ${value}`);
-}
-
 export default class MeetingTypeSelect extends React.Component {
 
   render() {

--- a/src/components/EventCard/index.js
+++ b/src/components/EventCard/index.js
@@ -253,24 +253,32 @@ export default class EventCard extends React.Component {
             title={townHall.eventName || ''}
             description={this.state.currentEditing === 'meetingType' ? selectMeetingType : displayMeetingType}
           />
-          <p>Notes: {this.state.currentEditing === 'eventNotes' ? selectEventNotes : displayEditNotes}</p>
+          <label>Notes: </label>
+          <div>
+            {this.state.currentEditing === 'eventNotes' ? selectEventNotes : displayEditNotes}
+          </div>
+
           <EditableText 
+            label="Location"
             content={townHall.Location || ''}
             updateEvent={updateEvent}
             fieldKey='Location'
-            label="location"
           />
-          <p>{townHall.address} {displayAddressOrDateEdit}</p>
-          <p>{townHall.repeatingEvent ? `${townHall.repeatingEvent}` : 
+          <div>{townHall.address} {displayAddressOrDateEdit}</div>
+
+          <label>Date: </label>
+          <div>{townHall.repeatingEvent ? `${townHall.repeatingEvent}` : 
             `${townHall.dateString} at ${townHall.Time} ${townHall.timeZone}`} 
-            {displayAddressOrDateEdit}</p>
+            {displayAddressOrDateEdit}</div>
           {townHall.disclaimer && <p>{townHall.disclaimer}</p>}
-          <div>Link URL: {this.state.currentEditing === 'link' ? editLinkUrl : displayLinkUrl}</div>
+
+          <label>Link URL: </label>
+          <div>{this.state.currentEditing === 'link' ? editLinkUrl : displayLinkUrl}</div>
           <EditableText 
+            label="Link Name"
             content={townHall.linkName}
             updateEvent={updateEvent}
             fieldKey='linkName'
-            label="Link Name"
           />
 
           <Checkbox defaultChecked={townHall.ada_accessible} onChange={this.toggleAdaAccessible}>ADA Accessible</Checkbox>

--- a/src/components/EventCard/index.js
+++ b/src/components/EventCard/index.js
@@ -37,6 +37,8 @@ export default class EventCard extends React.Component {
     this.selectIconFlag = this.selectIconFlag.bind(this)
     this.setEditEventNotesTrue = this.setEditEventNotesTrue.bind(this)
     this.selectEventNotes = this.selectEventNotes.bind(this)
+    this.setEditLinkUrlTrue = this.setEditLinkUrlTrue.bind(this)
+    this.editLinkUrl = this.editLinkUrl.bind(this)
     this.stopEditing = this.stopEditing.bind(this)
     this.toggleAdaAccessible = this.toggleAdaAccessible.bind(this)
   }
@@ -140,6 +142,18 @@ export default class EventCard extends React.Component {
       this.setState({currentEditing: false})
   }
 
+  setEditLinkUrlTrue() {
+    this.setState({currentEditing: 'link'});
+  }
+
+  editLinkUrl({target}) {
+    const {
+      updateEvent,
+    } = this.props
+    updateEvent({link: target.value.trim()})
+    this.setState({currentEditing: false})
+  }
+
   stopEditing() {
       this.setState({currentEditing: false})
   }
@@ -181,6 +195,12 @@ export default class EventCard extends React.Component {
           <Icon type="edit" onClick={this.setEditEventNotesTrue} />
         </React.Fragment>
       );
+      const displayLinkUrl = (
+        <React.Fragment>
+          <span><a href={townHall.link}>{townHall.link}</a></span>
+          <Icon type="edit" onClick={this.setEditLinkUrlTrue} />
+        </React.Fragment>
+      );
       const displayAddressOrDateEdit = (
         <EditAddressOrDateButton 
           townHall={townHall}
@@ -215,6 +235,12 @@ export default class EventCard extends React.Component {
               <TextArea onPressEnter={this.selectEventNotes} defaultValue={townHall.Notes}/>
           </Row>
           )
+      const editLinkUrl = (
+        <Row type="flex" justify="start">
+          <Button icon="close" shape="circle" onClick={this.stopEditing}/>
+          <Input onPressEnter={this.editLinkUrl} defaultValue={townHall.link}/>
+        </Row>
+        )
       
       return (
         <Card 
@@ -239,17 +265,12 @@ export default class EventCard extends React.Component {
             `${townHall.dateString} at ${townHall.Time} ${townHall.timeZone}`} 
             {displayAddressOrDateEdit}</p>
           {townHall.disclaimer && <p>{townHall.disclaimer}</p>}
-          <EditableText 
-            content={<a href={townHall.link} target="_blank">{townHall.link}</a>}
-            updateEvent={updateEvent}
-            fieldKey='link'
-            label="link"
-          />
+          <div>Link URL: {this.state.currentEditing === 'link' ? editLinkUrl : displayLinkUrl}</div>
           <EditableText 
             content={townHall.linkName}
             updateEvent={updateEvent}
             fieldKey='linkName'
-            label="link name"
+            label="Link Name"
           />
 
           <Checkbox defaultChecked={townHall.ada_accessible} onChange={this.toggleAdaAccessible}>ADA Accessible</Checkbox>

--- a/src/components/EventCard/style.scss
+++ b/src/components/EventCard/style.scss
@@ -3,4 +3,11 @@
     .ant-card-actions > li > span i {
         width: unset;
     }
+    .ant-card-body {
+        label {
+            display:inline-block;
+            font-weight: bold;
+            padding-top: 1em;
+        }
+    }
 }

--- a/src/components/LocationForm/index.js
+++ b/src/components/LocationForm/index.js
@@ -142,7 +142,6 @@ class LocationForm extends React.Component {
 
   render() {
     const {
-      address,
       style,
       getFieldDecorator,
       tempAddress,

--- a/src/components/NotAuthLayout/index.js
+++ b/src/components/NotAuthLayout/index.js
@@ -12,7 +12,7 @@ import {
 } from 'antd';
 import AppHeader from '../../containers/DefaultLayout/Header';
 import './style.scss';
-import { MODERATOR_ACCESS, ADMIN_ACCESS } from '../../constants';
+import { ADMIN_ACCESS } from '../../constants';
 
 const {
   Header,

--- a/src/containers/DefaultLayout/index.js
+++ b/src/containers/DefaultLayout/index.js
@@ -27,7 +27,6 @@ import {
   EVENT_DOWNLOAD_ACCESS,
   ADMIN_ACCESS,
   PENDING_EVENTS_TAB,
-  LIVE_EVENTS_TAB,
 } from '../../constants';
 import DownloadApp from '../DownloadApp';
 

--- a/src/containers/DefaultLayout/index.js
+++ b/src/containers/DefaultLayout/index.js
@@ -122,46 +122,45 @@ class DefaultLayout extends Component {
       return (
         <Layout>
           <Header>
-              <AppHeader 
-                userName={user.username}
-                logOut={this.logOut}
-              />
-            </Header>
+            <AppHeader 
+              userName={user.username}
+              logOut={this.logOut}
+            />
+          </Header>
           <Layout>
-              <Sider
-                width={300}
-                style={{
-                  overflow: 'auto', 
-                  height: '100vh', 
-               
-                }}
-              > 
-                <SideNav 
-                    handleChangeTab={changeActiveEventTab}
-                    activeEventTab={activeEventTab}
-                    activeMenuItem={currentHashLocation}
-                    totalEventsCounts={totalEventsCounts}
-                />
-              </Sider>
+            <Sider
+              width={300}
+              style={{
+                overflow: 'auto', 
+                height: '100vh',
+              }}
+            > 
+              <SideNav 
+                handleChangeTab={changeActiveEventTab}
+                activeEventTab={activeEventTab}
+                activeMenuItem={currentHashLocation}
+                totalEventsCounts={totalEventsCounts}
+              />
+            </Sider>
+            <Content style={{
+              padding: 24, margin: 0, minHeight: 280,
+            }}>   
               <Switch>
-                <Content style={{
-                  padding: 24, margin: 0, minHeight: 280,
-                }}>       
-                  {routes.map((route, idx) => {
-                      return route.component ? (
-                      <Route 
-                        key={idx} 
-                        path={route.path} 
-                        exact={route.exact} 
-                        name={route.name} 
-                        render={props => (
-                          <route.component {...props} />
-                        )} />)
-                        : null
-                    },
-                  )}
-                </Content>
+                {routes.map((route, idx) => {
+                  return route.component ? (
+                    <Route 
+                      key={idx} 
+                      path={route.path} 
+                      exact={route.exact} 
+                      name={route.name} 
+                      render={props => (
+                        <route.component {...props} />
+                      )} />)
+                      : null
+                  },
+                )}
               </Switch>
+            </Content>
           </Layout>
         </Layout>
       )

--- a/src/containers/EventsDashboard/index.js
+++ b/src/containers/EventsDashboard/index.js
@@ -43,7 +43,6 @@ class EventsDashBoard extends React.Component {
       pathForEvents,
       requestEventsCounts,
       pendingOrLive,
-      eventsCounts,
     } = this.props;
     if (prevProps.pathForEvents !== pathForEvents && pathForEvents) {
       requestEvents(pathForEvents);

--- a/src/containers/LookupOldEvents/results.jsx
+++ b/src/containers/LookupOldEvents/results.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
     Button,
-    Select,
     Row,
     Col,
 } from 'antd';
@@ -23,9 +22,6 @@ const colors = {
     I: 'purple',
     None: 'gray',
 }
-
-const Option = Select.Option;
-
 
 class OldEventsResults extends React.Component {
 

--- a/src/containers/MoCLookupDashboard/index.js
+++ b/src/containers/MoCLookupDashboard/index.js
@@ -37,7 +37,6 @@ class MoCLookUpDashboard extends React.Component {
 
   render() {
     const {
-      allMocNamesIds,
       saveStateLeg,
       isModerator,
       saveCandidate,
@@ -94,7 +93,7 @@ class MoCLookUpDashboard extends React.Component {
 
 const mapStateToProps = state => ({
   allMocNamesIds: mocStateBranch.selectors.getAllMocsIds(state),
-    isModerator: userStateBranch.selectors.getModeratorStatus(state),
+  isModerator: userStateBranch.selectors.getModeratorStatus(state),
   radioValue: selectionStateBranch.selectors.getActiveFederalOrState(state),
   keySavePath: selectionStateBranch.selectors.getPeopleNameUrl(state),
   the116theCongress: mocStateBranch.selectors.get116thCongress(state),

--- a/src/containers/RsvpTable/index.js
+++ b/src/containers/RsvpTable/index.js
@@ -10,9 +10,6 @@ import {
   Tag,
 } from 'antd';
 import {
-  map,
-} from 'lodash';
-import {
   CSVLink,
 } from "react-csv";
 
@@ -91,7 +88,6 @@ class RSVPTable extends React.Component {
 
   render() {
     const {
-        allRsvpsForCsv,
         allCurrentRsvps,
         allCurrentRsvpsForCsv,
     } = this.props;

--- a/src/state/mocs/candidate-model.js
+++ b/src/state/mocs/candidate-model.js
@@ -31,12 +31,12 @@ export default class Candidate {
       let middlename = nameArray[1];
       let lastname = nameArray[2];
       if (firstname.length === 1 || middlename.length === 1) {
-        memberKey = lastname.toLowerCase().replace(/\,/g, '') + '_' + firstname.toLowerCase() + '_' + middlename.toLowerCase();
+        memberKey = lastname.toLowerCase().replace(/,/g, '') + '_' + firstname.toLowerCase() + '_' + middlename.toLowerCase();
       } else {
-        memberKey = middlename.toLowerCase() + lastname.toLowerCase().replace(/\,/g, '') + '_' + firstname.toLowerCase();
+        memberKey = middlename.toLowerCase() + lastname.toLowerCase().replace(/,/g, '') + '_' + firstname.toLowerCase();
       }
     } else {
-      memberKey = nameArray[1].toLowerCase().replace(/\,/g, '') + '_' + nameArray[0].toLowerCase();
+      memberKey = nameArray[1].toLowerCase().replace(/,/g, '') + '_' + nameArray[0].toLowerCase();
     }
     return memberKey;
   }

--- a/src/state/mocs/state-leg-model.js
+++ b/src/state/mocs/state-leg-model.js
@@ -32,12 +32,12 @@ export default class StateLeg {
       let middlename = nameArray[1];
       let lastname = nameArray[2];
       if (firstname.length === 1 || middlename.length === 1) {
-        memberKey = lastname.toLowerCase().replace(/\,/g, '') + '_' + firstname.toLowerCase() + '_' + middlename.toLowerCase();
+        memberKey = lastname.toLowerCase().replace(/,/g, '') + '_' + firstname.toLowerCase() + '_' + middlename.toLowerCase();
       } else {
-        memberKey = middlename.toLowerCase() + lastname.toLowerCase().replace(/\,/g, '') + '_' + firstname.toLowerCase();
+        memberKey = middlename.toLowerCase() + lastname.toLowerCase().replace(/,/g, '') + '_' + firstname.toLowerCase();
       }
     } else {
-      memberKey = nameArray[1].toLowerCase().replace(/\,/g, '') + '_' + nameArray[0].toLowerCase();
+      memberKey = nameArray[1].toLowerCase().replace(/,/g, '') + '_' + nameArray[0].toLowerCase();
     }
     return memberKey;
   }

--- a/src/state/subscribers/selectors.js
+++ b/src/state/subscribers/selectors.js
@@ -1,4 +1,4 @@
-import { createSelector } from 'reselect';
+// import { createSelector } from 'reselect';
 
 export const getSubscriberToEdit = (state) => state.subscribers.editSubscriber;
 export const getSubscriberEmails = (state) => {

--- a/src/utils/firebaseinit.js
+++ b/src/utils/firebaseinit.js
@@ -1,6 +1,8 @@
 // FIREBASE METHODS
 // Initialize Firebase
-import firebase from 'firebase';
+import firebase from 'firebase/app';
+import 'firebase/auth';
+import 'firebase/database';
 
 const PREFIX = process.env.NODE_ENV === "production" ? "REACT_APP_PROD" : "REACT_APP_TESTING";
 const config = {


### PR DESCRIPTION
Mostly straightforward removal of unnecessary variables and functions. 

The AntD Paragraph in the EditableText component doesn't want to let us use HTML as child content, so the only way I could find to display a clickable, editable URL was to replace it with the jsx display/edit pattern we're using for other parts of the card. 

I had to move some markup around in the Event Card, so I did some very basic styling while I was at it to make things a little more consistent. 

I followed this advice in updating the firebase importing to remove that warning: https://github.com/firebase/firebase-js-sdk/issues/807